### PR TITLE
Add a Promotion System

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,41 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="DO_NOT_FORMAT">
+      <list>
+        <fileSet type="globPattern" pattern="CHANGELOG.md" />
+        <fileSet type="globPattern" pattern="docs/**.md" />
+      </list>
+    </option>
+    <JSCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+    </JSCodeStyleSettings>
+    <JavaCodeStyleSettings>
+      <option name="GENERATE_FINAL_LOCALS" value="true" />
+      <option name="GENERATE_FINAL_PARAMETERS" value="true" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999999999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999999999" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value>
+          <package name="org.mockito.ArgumentMatchers" withSubpackages="false" static="true" />
+          <package name="org.junit.jupiter.api.Assertions" withSubpackages="false" static="true" />
+          <package name="org.mockito.Mockito" withSubpackages="false" static="true" />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
+    <Markdown>
+      <option name="MAX_LINES_AROUND_BLOCK_ELEMENTS" value="0" />
+      <option name="MAX_LINES_BETWEEN_PARAGRAPHS" value="0" />
+    </Markdown>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="0" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <option name="BLANK_LINES_AROUND_FIELD" value="1" />
+    </codeStyleSettings>
+    <codeStyleSettings language="Markdown">
+      <option name="WRAP_ON_TYPING" value="1" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,80 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="JavaDoc" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="TOP_LEVEL_CLASS_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="package" />
+          <option name="REQUIRED_TAGS" value="@param" />
+        </value>
+      </option>
+      <option name="INNER_CLASS_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="private" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="METHOD_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="protected" />
+          <option name="REQUIRED_TAGS" value="@return@param@throws or @exception" />
+        </value>
+      </option>
+      <option name="FIELD_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="private" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="IGNORE_DEPRECATED" value="false" />
+      <option name="IGNORE_JAVADOC_PERIOD" value="true" />
+      <option name="IGNORE_DUPLICATED_THROWS" value="false" />
+      <option name="IGNORE_POINT_TO_ITSELF" value="false" />
+      <option name="myAdditionalJavadocTags" value="return" />
+      <option name="MODULE_OPTIONS">
+        <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="public" />
+        <option name="REQUIRED_TAGS" value="" />
+      </option>
+      <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="public" />
+      <option name="REQUIRED_TAGS" value="" />
+    </inspection_tool>
+    <inspection_tool class="JavadocDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ADDITIONAL_TAGS" value="return" />
+      <option name="IGNORE_THROWS_DUPLICATE" value="false" />
+      <option name="IGNORE_PERIOD_PROBLEM" value="false" />
+    </inspection_tool>
+    <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="REPORT_VARIABLES" value="true" />
+      <option name="REPORT_PARAMETERS" value="true" />
+      <option name="REPORT_IMPLICIT_FINALS" value="false" />
+    </inspection_tool>
+    <inspection_tool class="MissingJavadoc" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="TOP_LEVEL_CLASS_SETTINGS">
+        <Options>
+          <option name="MINIMAL_VISIBILITY" value="package" />
+          <option name="REQUIRED_TAGS" value="@param" />
+        </Options>
+      </option>
+      <option name="INNER_CLASS_SETTINGS">
+        <Options>
+          <option name="MINIMAL_VISIBILITY" value="private" />
+        </Options>
+      </option>
+      <option name="METHOD_SETTINGS">
+        <Options>
+          <option name="MINIMAL_VISIBILITY" value="protected" />
+          <option name="REQUIRED_TAGS" value="@return@param@throws or @exception" />
+        </Options>
+      </option>
+      <option name="FIELD_SETTINGS">
+        <Options>
+          <option name="MINIMAL_VISIBILITY" value="private" />
+        </Options>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="WARNING_ATTRIBUTES">
+      <option name="ignoreObjectMethods" value="false" />
+      <option name="ignoreAnonymousClassMethods" value="false" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ We use [JDA (Java Discord API)](https://github.com/DV8FromTheWorld/JDA) as the B
     - a tag to mark solved posts
     - tags to keep when a post is solved
     - a order by which tags are sorted
+
+- Promotion System:
+  - Ranks:
+    - A List of roles handled in the promotion system
+    - Sorted from lowest (top) to highest (down)
+  - a message as an embed, when a user is promoted. Supports placeholders: "%user%", "%newRole%", "%promoter%"
+  - Bypass-Roles:
+    - A List of roles that can circumvent all permission checks

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # DiscordBot
+
 A helper bot for the BetonQuest Community Discord.
 
-Requirements can be found on our [Notion page](https://betonquest.notion.site/BetonQuest-Discord-Bot-96d3fa5c28174494a8123005622be075).
+Requirements can be found on
+our [Notion page](https://betonquest.notion.site/BetonQuest-Discord-Bot-96d3fa5c28174494a8123005622be075).
 
 # Technology
+
 We use [JDA (Java Discord API)](https://github.com/DV8FromTheWorld/JDA) as the Backend API for this bot.
 
 # Features
@@ -37,3 +40,5 @@ We use [JDA (Java Discord API)](https://github.com/DV8FromTheWorld/JDA) as the B
   - a message as an embed, when a user is promoted. Supports placeholders: "%user%", "%newRole%", "%promoter%"
   - Bypass-Roles:
     - A List of roles that can circumvent all permission checks
+  - Promotion Cooldown:
+    - A cooldown in seconds, after which a user can be promoted again

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.github.DV8FromTheWorld</groupId>
       <artifactId>JDA</artifactId>
-      <version>v5.3.2</version>
+      <version>v5.5.1</version>
       <exclusions>
         <exclusion>
           <groupId>club.minnced</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,4 +83,27 @@
       <version>3.17.0</version>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>${project.groupId}.${project.artifactId}.${project.name}</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,20 +83,4 @@
       <version>3.17.0</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <systemPropertyVariables>
-              <java.util.logging.config.file>${project.basedir}/src/test/resources/logging-test.properties</java.util.logging.config.file>
-            </systemPropertyVariables>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/src/main/java/org/betonquest/discordbot/DiscordBot.java
+++ b/src/main/java/org/betonquest/discordbot/DiscordBot.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import org.betonquest.discordbot.config.BetonBotConfig;
+import org.betonquest.discordbot.modules.promotion.*;
 import org.betonquest.discordbot.modules.support.NewThreadListener;
 import org.betonquest.discordbot.modules.support.SolveCommand;
 import org.betonquest.discordbot.modules.support.ThreadAutoCloseScheduler;
@@ -81,5 +82,7 @@ public final class DiscordBot {
         new ThreadUpdateListener(api, config);
 
         new ThreadAutoCloseScheduler(api, config, guild);
+
+        new PromoteCommand(api, config);
     }
 }

--- a/src/main/java/org/betonquest/discordbot/DiscordBot.java
+++ b/src/main/java/org/betonquest/discordbot/DiscordBot.java
@@ -6,7 +6,8 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import org.betonquest.discordbot.config.BetonBotConfig;
-import org.betonquest.discordbot.modules.promotion.*;
+import org.betonquest.discordbot.modules.promotion.PromoteCommand;
+import org.betonquest.discordbot.modules.promotion.PromotionCache;
 import org.betonquest.discordbot.modules.support.NewThreadListener;
 import org.betonquest.discordbot.modules.support.SolveCommand;
 import org.betonquest.discordbot.modules.support.ThreadAutoCloseScheduler;
@@ -83,6 +84,11 @@ public final class DiscordBot {
 
         new ThreadAutoCloseScheduler(api, config, guild);
 
-        new PromoteCommand(api, config);
+        try {
+            final PromotionCache promotionCache = new PromotionCache(Paths.get("promotionCache.yml"), config);
+            new PromoteCommand(api, config, promotionCache);
+        } catch (final IOException e) {
+            LOGGER.error("Could not read the promotion cache file 'promotionCache.yml'! Reason: ", e);
+        }
     }
 }

--- a/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
+++ b/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
@@ -33,7 +33,7 @@ public class BetonBotConfig {
     /**
      * The guild id for the target Discord server.
      */
-    public final Long guildID;
+    public final long guildID;
 
     /**
      * Should the commands be registered again.
@@ -59,12 +59,12 @@ public class BetonBotConfig {
     /**
      * The Tag-ID to apply to solved Support Posts.
      */
-    public final Long supportTagsSolved;
+    public final long supportTagsSolved;
 
     /**
      * The Tag-ID to apply to Support Posts by default if no tag is set.
      */
-    public final Long supportTagsDefault;
+    public final long supportTagsDefault;
 
     /**
      * An Order by which ForumTags are sorted when applied to Support Posts.
@@ -104,10 +104,10 @@ public class BetonBotConfig {
     /**
      * The cooldown in seconds before a User can be promoted again.
      */
-    public final Long promotionCooldown;
+    public final int promotionCooldown;
 
     /**
-     * Create a new Instance of the Configuration Class
+     * Create a new Instance of the Configuration Class.
      *
      * @param configPath the path of the config file
      * @throws IOException is thrown, when reading or writing the file coursed problems.
@@ -131,7 +131,7 @@ public class BetonBotConfig {
         promotionRanks = getOrCreate("Promotion.Ranks", Lists.newArrayList(-1L), config);
         promotionEmbed = getOrCreateEmbed("Promotion.PromotionMessage", config);
         promotionBypassRoles = getOrCreate("Promotion.BypassRoles", Lists.newArrayList(-1L), config);
-        promotionCooldown = getOrCreate("Promotion.Cooldown", 0L, config);
+        promotionCooldown = getOrCreate("Promotion.Cooldown", 0, config);
 
         if (updateCommands) {
             config.put("UpdateCommands", false);

--- a/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
+++ b/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
@@ -102,6 +102,8 @@ public class BetonBotConfig {
     public final List<Long> promotionBypassRoles;
 
     /**
+     * Create a new Instance of the Configuration Class
+     *
      * @param configPath the path of the config file
      * @throws IOException is thrown, when reading or writing the file coursed problems.
      */

--- a/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
+++ b/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
@@ -102,6 +102,11 @@ public class BetonBotConfig {
     public final List<Long> promotionBypassRoles;
 
     /**
+     * The cooldown in seconds before a User can be promoted again.
+     */
+    public final Long promotionCooldown;
+
+    /**
      * Create a new Instance of the Configuration Class
      *
      * @param configPath the path of the config file
@@ -126,6 +131,7 @@ public class BetonBotConfig {
         promotionRanks = getOrCreate("Promotion.Ranks", Lists.newArrayList(-1L), config);
         promotionEmbed = getOrCreateEmbed("Promotion.PromotionMessage", config);
         promotionBypassRoles = getOrCreate("Promotion.BypassRoles", Lists.newArrayList(-1L), config);
+        promotionCooldown = getOrCreate("Promotion.Cooldown", 0L, config);
 
         if (updateCommands) {
             config.put("UpdateCommands", false);
@@ -162,7 +168,7 @@ public class BetonBotConfig {
                     try {
                         return (T) value;
                     } catch (final Exception e) {
-                        LOGGER.warn("Could not cast Config Entry '" + key + "'. Using default one.", e);
+                        LOGGER.warn("Could not cast Config Entry '{}'. Using default one.", key, e);
                     }
                 }
             }

--- a/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
+++ b/src/main/java/org/betonquest/discordbot/config/BetonBotConfig.java
@@ -87,6 +87,21 @@ public class BetonBotConfig {
     public final int supportAutoCloseTimeout;
 
     /**
+     * A ordered List of Roles contained in the Promotion Ladder.
+     */
+    public final List<Long> promotionRanks;
+
+    /**
+     * The message to show when a User was promoted to a new rank.
+     */
+    public final ConfigEmbedBuilder promotionEmbed;
+
+    /**
+     * A List of Roles that can bypass checks in the Promotion System.
+     */
+    public final List<Long> promotionBypassRoles;
+
+    /**
      * @param configPath the path of the config file
      * @throws IOException is thrown, when reading or writing the file coursed problems.
      */
@@ -106,6 +121,9 @@ public class BetonBotConfig {
         supportSolvedEmbed = getOrCreateEmbed("Support.SolvedMessage", config);
         supportAutoCloseCheckInterval = getOrCreate("Support.AutoCloseCheckInterval", 20, config);
         supportAutoCloseTimeout = getOrCreate("Support.AutoCloseTimeout", 15, config);
+        promotionRanks = getOrCreate("Promotion.Ranks", Lists.newArrayList(-1L), config);
+        promotionEmbed = getOrCreateEmbed("Promotion.PromotionMessage", config);
+        promotionBypassRoles = getOrCreate("Promotion.BypassRoles", Lists.newArrayList(-1L), config);
 
         if (updateCommands) {
             config.put("UpdateCommands", false);

--- a/src/main/java/org/betonquest/discordbot/modules/ForumTagHolder.java
+++ b/src/main/java/org/betonquest/discordbot/modules/ForumTagHolder.java
@@ -52,7 +52,7 @@ public class ForumTagHolder {
      * @return true if the {@link List} contains the "solved" tag, otherwise false
      */
     public static boolean isSolved(final List<ForumTag> channelTags, final BetonBotConfig config) {
-        return channelTags.stream().anyMatch(tag -> config.supportTagsSolved.equals(tag.getIdLong()));
+        return channelTags.stream().anyMatch(tag -> config.supportTagsSolved == tag.getIdLong());
     }
 
     /**

--- a/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
+++ b/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
@@ -13,13 +13,12 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import org.betonquest.discordbot.config.BetonBotConfig;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 
@@ -156,11 +155,9 @@ public class PromoteCommand extends ListenerAdapter {
         }
 
         if (!promotionCache.isPromotable(promotionTarget)) {
-            final Duration cooldown = Duration.of(config.promotionCooldown, ChronoUnit.SECONDS);
-            final String readableCooldown = String.format("%d days %d hours %d minutes",
-                    cooldown.toDaysPart(), cooldown.toHoursPart() % 24, cooldown.toMinutesPart() % 60);
+            final String time = TimeFormat.RELATIVE.format(promotionCache.getTimeOfNextPromotion(promotionTarget) * 1000);
             event.reply("The user was previously promoted and is still on cooldown.\n"
-                            + "Promotions are only allowed every " + readableCooldown + ".")
+                            + "The next promotion is possible " + time + ".")
                     .setEphemeral(true).queue();
             return;
         }

--- a/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
+++ b/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
@@ -98,8 +98,8 @@ public class PromoteCommand extends ListenerAdapter {
             return;
         }
 
-        final Long highestRoleOfExecutor = promotionRolesOfExecutor.getLast().getIdLong();
-        if (noBypassRole && config.promotionRanks.getFirst().equals(highestRoleOfExecutor)) {
+        final Long highestRoleOfExecutor = getLast(promotionRolesOfExecutor).getIdLong();
+        if (noBypassRole && getFirst(config.promotionRanks).equals(highestRoleOfExecutor)) {
             event.reply("There are no roles below you in the Promotion Ladder. You cannot use this command.")
                     .setEphemeral(true).queue();
             return;
@@ -108,14 +108,14 @@ public class PromoteCommand extends ListenerAdapter {
         final List<Role> promotionRolesOfTarget = filterAndSortByPromotionLadder(promotionTarget.getRoles());
 
         final Long highestRoleIdOfTarget = promotionRolesOfTarget.isEmpty()
-                ? -1
-                : promotionRolesOfTarget.getLast().getIdLong();
+                ? -1L
+                : getLast(promotionRolesOfTarget).getIdLong();
 
         final int indexOfHighestExecutorRole = config.promotionRanks.indexOf(highestRoleOfExecutor);
         final int indexOfHighestTargetRole = config.promotionRanks.indexOf(highestRoleIdOfTarget);
         if (noBypassRole && indexOfHighestTargetRole >= indexOfHighestExecutorRole) {
-            event.reply("The target user is already ranked higher or equally high ranked as you.\n" +
-                            "You can only rank up to one role lower than yourself.")
+            event.reply("The target user is already ranked higher or equally high ranked as you.\n"
+                            + "You can only rank up to one role lower than yourself.")
                     .setEphemeral(true).queue();
             return;
         }
@@ -163,5 +163,13 @@ public class PromoteCommand extends ListenerAdapter {
                 .filter(role -> config.promotionRanks.contains(role.getIdLong()))
                 .sorted(Comparator.comparingInt(role -> config.promotionRanks.indexOf(role.getIdLong())))
                 .toList();
+    }
+
+    private <T> T getFirst(List<T> list) {
+        return list.get(0);
+    }
+
+    private <T> T getLast(List<T> list) {
+        return list.get(list.size() - 1);
     }
 }

--- a/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
+++ b/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
@@ -1,0 +1,167 @@
+package org.betonquest.discordbot.modules.promotion;
+
+import java.util.*;
+
+import org.betonquest.discordbot.config.*;
+import org.slf4j.*;
+
+import net.dv8tion.jda.api.*;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.interaction.command.*;
+import net.dv8tion.jda.api.hooks.*;
+import net.dv8tion.jda.api.interactions.commands.*;
+import net.dv8tion.jda.api.interactions.commands.build.*;
+
+/**
+ * A `promote` command to promote users up in a ranking ladder
+ */
+public class PromoteCommand extends ListenerAdapter {
+    /**
+     * Logger instance.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(PromoteCommand.class);
+
+    /**
+     * The command name.
+     */
+    public static final String COMMAND = "promote";
+
+    /**
+     * The command option user.
+     */
+    public static final String USER_OPTION_NAME = "user";
+
+    /**
+     * The {@link BetonBotConfig} instance.
+     */
+    private final BetonBotConfig config;
+
+    /**
+     * Create a new `promote` command instance.
+     *
+     * @param api    The {@link JDA} instance
+     * @param config The {@link BetonBotConfig} instance
+     */
+    public PromoteCommand(final JDA api, final BetonBotConfig config) {
+        super();
+        this.config = config;
+        if (config.promotionRanks.isEmpty()) {
+            LOGGER.warn("No support channels where found or set!");
+            return;
+        }
+        if (config.promotionEmbed == null) {
+            LOGGER.warn("No support closed message was found or set!");
+        }
+
+        if (config.updateCommands) {
+            api.updateCommands().addCommands(
+                    Commands.slash(COMMAND, "Promote a player up the ranking ladder.")
+                            .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR))
+                            .addOption(OptionType.USER, USER_OPTION_NAME, "The User to promote", true)
+            ).queue();
+        }
+        api.addEventListener(this);
+    }
+
+    @Override
+    public void onSlashCommandInteraction(final SlashCommandInteractionEvent event) {
+        if (!COMMAND.equals(event.getName())) {
+            return;
+        }
+
+        final OptionMapping option = event.getOption(USER_OPTION_NAME);
+        if (option == null) {
+            event.reply("You need to specify a user to promote.").setEphemeral(true).queue();
+            return;
+        }
+
+        final Member promotionTarget = option.getAsMember();
+        if (promotionTarget == null) {
+            event.reply("You need to specify a user to promote.").setEphemeral(true).queue();
+            return;
+        }
+
+        final Member cmdExecutor = event.getInteraction().getMember();
+        if (cmdExecutor == null) {
+            LOGGER.error("The promote command was triggered without a member!");
+            return;
+        }
+
+        final List<Role> executorRoles = cmdExecutor.getRoles();
+        final boolean noBypassRole = executorRoles.stream().noneMatch(r ->
+                config.promotionBypassRoles.contains(r.getIdLong()));
+
+        final List<Role> promotionRolesOfExecutor = filterAndSortByPromotionLadder(executorRoles);
+        if (noBypassRole && promotionRolesOfExecutor.isEmpty()) {
+            event.reply("You need to have a promotable Rank yourself to use this command!")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        final Long highestRoleOfExecutor = promotionRolesOfExecutor.getLast().getIdLong();
+        if (noBypassRole && config.promotionRanks.getFirst().equals(highestRoleOfExecutor)) {
+            event.reply("There are no roles below you in the Promotion Ladder. You cannot use this command.")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        final List<Role> promotionRolesOfTarget = filterAndSortByPromotionLadder(promotionTarget.getRoles());
+
+        final Long highestRoleIdOfTarget = promotionRolesOfTarget.isEmpty()
+                ? -1
+                : promotionRolesOfTarget.getLast().getIdLong();
+
+        final int indexOfHighestExecutorRole = config.promotionRanks.indexOf(highestRoleOfExecutor);
+        final int indexOfHighestTargetRole = config.promotionRanks.indexOf(highestRoleIdOfTarget);
+        if (noBypassRole && indexOfHighestTargetRole >= indexOfHighestExecutorRole) {
+            event.reply("The target user is already ranked higher or equally high ranked as you.\n" +
+                            "You can only rank up to one role lower than yourself.")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        final int indexOfNewRoleOfTarget = indexOfHighestTargetRole + 1;
+        if (noBypassRole && indexOfNewRoleOfTarget >= indexOfHighestExecutorRole) {
+            event.reply("You cannot promote other users up to your own rank.")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        if (!noBypassRole && indexOfNewRoleOfTarget == config.promotionRanks.size()) {
+            event.reply("The target user is already on the highest rank")
+                    .setEphemeral(true).queue();
+            return;
+        }
+
+        final Long newRoleIdOfTarget = config.promotionRanks.get(indexOfNewRoleOfTarget);
+        addRoleToUser(event, newRoleIdOfTarget, promotionTarget, cmdExecutor);
+    }
+
+    private void addRoleToUser(final SlashCommandInteractionEvent event, final Long roleId,
+                               final Member member, final Member cmdExecutor) {
+        final Guild guild = member.getGuild();
+        final Role newRole = guild.getRoleById(roleId);
+        if (newRole == null) {
+            LOGGER.error("The role id " + roleId + " does not exist in the Guild!");
+            event.reply("The role id " + roleId + " does not exist in the Guild!").setEphemeral(true).queue();
+            return;
+        }
+        LOGGER.info("Promoting Member %d to Role %d...".formatted(member.getIdLong(), roleId));
+        guild.addRoleToMember(member, newRole).queue((nothing) -> {
+            LOGGER.info("Successfully promoted Member %d to Role %d!".formatted(member.getIdLong(), roleId));
+            final MessageEmbed embed = config.promotionEmbed
+                    .variable("user", member.getAsMention())
+                    .variable("newRole", newRole.getName())
+                    .variable("promoter", cmdExecutor.getEffectiveName())
+                    .getEmbed();
+            event.replyEmbeds(embed).setEphemeral(false).queue();
+        });
+    }
+
+    private List<Role> filterAndSortByPromotionLadder(final List<Role> roles) {
+        return roles.stream()
+                .filter(role -> config.promotionRanks.contains(role.getIdLong()))
+                .sorted(Comparator.comparingInt(role -> config.promotionRanks.indexOf(role.getIdLong())))
+                .toList();
+    }
+}

--- a/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
+++ b/src/main/java/org/betonquest/discordbot/modules/promotion/PromoteCommand.java
@@ -12,7 +12,9 @@ import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import org.betonquest.discordbot.config.BetonBotConfig;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,15 +70,18 @@ public class PromoteCommand extends ListenerAdapter {
         if (config.promotionEmbed == null) {
             LOGGER.warn("No support closed message was found or set!");
         }
-
-        if (config.updateCommands) {
-            api.updateCommands().addCommands(
-                    Commands.slash(COMMAND, "Promote a player up the ranking ladder.")
-                            .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR))
-                            .addOption(OptionType.USER, USER_OPTION_NAME, "The User to promote", true)
-            ).queue();
-        }
         api.addEventListener(this);
+    }
+
+    /**
+     * Get the slash command data for this command.
+     *
+     * @return The slash command data
+     */
+    public @NotNull SlashCommandData getSlashCommandData() {
+        return Commands.slash(COMMAND, "Promote a player up the ranking ladder.")
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR))
+                .addOption(OptionType.USER, USER_OPTION_NAME, "The User to promote", true);
     }
 
     @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})

--- a/src/main/java/org/betonquest/discordbot/modules/promotion/PromotionCache.java
+++ b/src/main/java/org/betonquest/discordbot/modules/promotion/PromotionCache.java
@@ -42,7 +42,7 @@ public class PromotionCache {
     /**
      * The cooldown period in seconds before a user can be promoted again.
      */
-    private final Long promotionCooldown;
+    private final int promotionCooldown;
 
     /**
      * Creates a new PromotionCache instance.

--- a/src/main/java/org/betonquest/discordbot/modules/promotion/PromotionCache.java
+++ b/src/main/java/org/betonquest/discordbot/modules/promotion/PromotionCache.java
@@ -1,0 +1,100 @@
+package org.betonquest.discordbot.modules.promotion;
+
+import net.dv8tion.jda.api.entities.Member;
+import org.betonquest.discordbot.config.BetonBotConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A cache to manage user promotions with a cooldown mechanism.
+ * It stores the last promotion time for each user and checks if they can be promoted again.
+ */
+public class PromotionCache {
+    /**
+     * Logger instance.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(PromotionCache.class);
+
+    /**
+     * The YAML parser instance used for reading and writing the cache.
+     */
+    private final Yaml yaml;
+
+    /**
+     * The path to the cache file where promotion data is stored.
+     */
+    private final Path cachePath;
+
+    /**
+     * A map that caches the last promotion time for each user.
+     */
+    private final Map<Long, Long> promotions;
+
+    /**
+     * The cooldown period in seconds before a user can be promoted again.
+     */
+    private final Long promotionCooldown;
+
+    /**
+     * Creates a new PromotionCache instance.
+     *
+     * @param cachePath the path to the cache file
+     * @param config    the BetonBotConfig instance containing the promotion cooldown
+     * @throws IOException if an I/O error occurs while reading or writing the cache file
+     */
+    public PromotionCache(final Path cachePath, final BetonBotConfig config) throws IOException {
+        this.cachePath = cachePath;
+        this.yaml = getYaml();
+        this.promotions = getConfig(yaml, cachePath);
+        this.promotionCooldown = config.promotionCooldown;
+    }
+
+    /**
+     * Checks if a user is promotable and updates the cache if so.
+     *
+     * @param member the member to check
+     * @return true if the user can be promoted, false otherwise
+     */
+    public boolean isPromotable(final Member member) {
+        final long userID = member.getIdLong();
+        final long currentTime = Instant.now().getEpochSecond();
+        final Long lastTime = promotions.getOrDefault(userID, -1L);
+        if (lastTime + promotionCooldown < currentTime) {
+            promotions.put(userID, currentTime);
+            try {
+                yaml.dump(promotions, Files.newBufferedWriter(cachePath));
+            } catch (final IOException e) {
+                LOGGER.warn("Error while writing promotion cache.", e);
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private Yaml getYaml() {
+        final DumperOptions options = new DumperOptions();
+        options.setIndent(4);
+        options.setIndicatorIndent(2);
+        options.setWidth(120);
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        return new Yaml(options);
+    }
+
+    private Map<Long, Long> getConfig(final Yaml yaml, final Path cachePath) throws IOException {
+        if (Files.exists(cachePath)) {
+            return yaml.load(Files.newInputStream(cachePath));
+        } else {
+            return new LinkedHashMap<>();
+        }
+    }
+}

--- a/src/main/java/org/betonquest/discordbot/modules/support/SolveCommand.java
+++ b/src/main/java/org/betonquest/discordbot/modules/support/SolveCommand.java
@@ -18,14 +18,14 @@ import org.slf4j.LoggerFactory;
  */
 public class SolveCommand extends ListenerAdapter {
     /**
-     * Logger instance.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(SolveCommand.class);
-
-    /**
      * The command name.
      */
     public static final String COMMAND = "solve";
+
+    /**
+     * Logger instance.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SolveCommand.class);
 
     /**
      * The {@link BetonBotConfig} instance.

--- a/src/main/java/org/betonquest/discordbot/modules/support/SolveCommand.java
+++ b/src/main/java/org/betonquest/discordbot/modules/support/SolveCommand.java
@@ -8,8 +8,10 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import org.betonquest.discordbot.config.BetonBotConfig;
 import org.betonquest.discordbot.modules.ForumTagHolder;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,14 +50,17 @@ public class SolveCommand extends ListenerAdapter {
         if (config.supportSolvedEmbed == null) {
             LOGGER.warn("No support closed message was found or set!");
         }
-
-        if (config.updateCommands) {
-            api.updateCommands().addCommands(
-                    Commands.slash(COMMAND, "Mark a support thread as solved.")
-                            .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR))
-            ).queue();
-        }
         api.addEventListener(this);
+    }
+
+    /**
+     * Get the slash command data for this command.
+     *
+     * @return The slash command data
+     */
+    public @NotNull SlashCommandData getSlashCommandData() {
+        return Commands.slash(COMMAND, "Mark a support thread as solved.")
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR));
     }
 
     @Override

--- a/src/main/java/org/betonquest/discordbot/modules/support/SolveCommand.java
+++ b/src/main/java/org/betonquest/discordbot/modules/support/SolveCommand.java
@@ -18,14 +18,14 @@ import org.slf4j.LoggerFactory;
  */
 public class SolveCommand extends ListenerAdapter {
     /**
-     * The command name.
-     */
-    public static final String COMMAND = "solve";
-
-    /**
      * Logger instance.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(SolveCommand.class);
+
+    /**
+     * The command name.
+     */
+    public static final String COMMAND = "solve";
 
     /**
      * The {@link BetonBotConfig} instance.

--- a/src/main/java/org/betonquest/discordbot/modules/support/ThreadAutoCloseScheduler.java
+++ b/src/main/java/org/betonquest/discordbot/modules/support/ThreadAutoCloseScheduler.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -84,7 +83,7 @@ public class ThreadAutoCloseScheduler extends ListenerAdapter implements Runnabl
      */
     @Override
     public void run() {
-        final OffsetDateTime timeout = OffsetDateTime.now().minus(config.supportAutoCloseTimeout, ChronoUnit.MINUTES);
+        final OffsetDateTime timeout = OffsetDateTime.now().minusMinutes(config.supportAutoCloseTimeout);
         supportForums.stream()
                 .map(IThreadContainer::getThreadChannels)
                 .flatMap(Collection::stream)

--- a/src/main/java/org/betonquest/discordbot/modules/welcome/WelcomeMessageListener.java
+++ b/src/main/java/org/betonquest/discordbot/modules/welcome/WelcomeMessageListener.java
@@ -20,10 +20,10 @@ public class WelcomeMessageListener extends ListenerAdapter {
     /**
      * Create a new {@link WelcomeMessageListener}
      *
-     * @param api    the {@link JDA} instance
+     * @param api          the {@link JDA} instance
      * @param welcomeEmoji the welcome emoji to send to every new member
      * @throws IllegalArgumentException if the welcome emoji is null
-     * @throws IllegalStateException if the welcome emoji is not valid
+     * @throws IllegalStateException    if the welcome emoji is not valid
      */
     public WelcomeMessageListener(final JDA api, @Nullable final String welcomeEmoji) {
         super();


### PR DESCRIPTION
This PR adds a Promotion System containing:
- A configurable List of Roles contained in the Ranking Ladder
- A configurable Embed that is send when a User is promoted to a new Role
- A configurable List of Roles that can circumvent Security Checks

A not-bypassing user is only able to promote up to one role beneath themselves. They need to have a role contained in the ranking ladder themselves.